### PR TITLE
[Fix #604] Remove `remove_reference` checks from `Rails/ReversibleMigration`

### DIFF
--- a/lib/rubocop/cop/rails/reversible_migration.rb
+++ b/lib/rubocop/cop/rails/reversible_migration.rb
@@ -179,7 +179,7 @@ module RuboCop
         MSG = '%<action>s is not reversible.'
 
         def_node_matcher :irreversible_schema_statement_call, <<~PATTERN
-          (send nil? ${:change_column :execute :remove_belongs_to :remove_reference} ...)
+          (send nil? ${:change_column :execute :remove_belongs_to} ...)
         PATTERN
 
         def_node_matcher :drop_table_call, <<~PATTERN

--- a/lib/rubocop/cop/rails/reversible_migration.rb
+++ b/lib/rubocop/cop/rails/reversible_migration.rb
@@ -179,7 +179,7 @@ module RuboCop
         MSG = '%<action>s is not reversible.'
 
         def_node_matcher :irreversible_schema_statement_call, <<~PATTERN
-          (send nil? ${:change_column :execute :remove_belongs_to} ...)
+          (send nil? ${:change_column :execute} ...)
         PATTERN
 
         def_node_matcher :drop_table_call, <<~PATTERN

--- a/spec/rubocop/cop/rails/reversible_migration_spec.rb
+++ b/spec/rubocop/cop/rails/reversible_migration_spec.rb
@@ -171,20 +171,6 @@ RSpec.describe RuboCop::Cop::Rails::ReversibleMigration, :config do
     RUBY
   end
 
-  context 'remove_belongs_to' do
-    it_behaves_like 'accepts', 'up_only', <<~RUBY
-      up_only { remove_belongs_to(:products, :user, index: false) }
-    RUBY
-
-    it_behaves_like 'offense', 'remove_belongs_to', <<~RUBY
-      remove_belongs_to(:products, :user, index: false)
-    RUBY
-
-    it_behaves_like 'offense', 'remove_belongs_to', <<~RUBY
-      remove_belongs_to(:products, :supplier, polymorphic: true)
-    RUBY
-  end
-
   context 'remove_column' do
     it_behaves_like 'accepts', 'remove_column(with type)', <<~RUBY
       remove_column(:suppliers, :qualification, :string)
@@ -210,20 +196,6 @@ RSpec.describe RuboCop::Cop::Rails::ReversibleMigration, :config do
 
     it_behaves_like 'offense', 'remove_foreign_key(without table)', <<~RUBY
       remove_foreign_key :accounts, column: :owner_id
-    RUBY
-  end
-
-  context 'remove_reference' do
-    it_behaves_like 'accepts', 'up_only', <<~RUBY
-      up_only { remove_reference(:products, :user, index: false) }
-    RUBY
-
-    it_behaves_like 'offense', 'remove_reference', <<~RUBY
-      remove_reference(:products, :user, index: false)
-    RUBY
-
-    it_behaves_like 'offense', 'remove_reference', <<~RUBY
-      remove_reference(:products, :supplier, polymorphic: true)
     RUBY
   end
 


### PR DESCRIPTION
Fixes #604

This removes the newly added check for `remove_reference` in `Rails/ReversibleMIgration`, as well as the recently added check for `remove_belongs_to`, an alias of `remove_reference`.

As discussed in #604, both of these statements are reversible, since their inverse methods are included in [ActiveRecord::Migration::CommandRecorder](https://api.rubyonrails.org/classes/ActiveRecord/Migration/CommandRecorder.html)

It is true that any options that were used in the `add_reference/add_belongs_to` statements need to also be included in the `remove_reference` statement; otherwise, a rollback will not properly restore the schema back to its previous state; however, the same could be said of several other reversible statements, such as `remove_column`.

For example, if I add a column with additional options, like `default`:

```ruby
    add_column :comments, :position, :integer, default: 0
```

and then later remove that column without specifying those same options

```ruby
    remove_column :comments, :position, :integer
```

Then it won't properly rollback to its previous state. It will be missing the default.

Since there is no easy way to check that all of the options originally provided to the corresponding `add_*` statement are present in the `remove_*` statement, it seems impractical to have a cop for these methods. It will most likely result in more users disabling the cop entirely.

-----------------

Before submitting the PR make sure the following are checked:

* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [x] Added tests.
* [x] Ran `bundle exec rake default`. It executes all tests and runs RuboCop on its own code.
* [ ] Added an entry (file) to the [changelog folder](https://github.com/rubocop/rubocop-rails/blob/master/changelog/) named `{change_type}_{change_description}.md` if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop/rubocop/blob/master/CONTRIBUTING.md#changelog-entry-format) for details.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] If this is a new cop, consider making a corresponding update to the [Rails Style Guide](https://github.com/rubocop/rails-style-guide).

[1]: https://chris.beams.io/posts/git-commit/
